### PR TITLE
feat: add Node.js DNI validator

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "idnumbers-js",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,0 +1,1 @@
+export * as SpainDNI from './nationalid/esp/dni.js';

--- a/js/src/nationalid/esp/dni.js
+++ b/js/src/nationalid/esp/dni.js
@@ -1,0 +1,16 @@
+const MAGIC_LETTERS = 'TRWAGMYFPDXBNJZSQVHLCKE';
+
+/**
+ * Validate Spain Documento Nacional de Identidad (DNI).
+ * @param {string} idNumber - The national ID number to validate.
+ * @returns {boolean} True if valid, false otherwise.
+ */
+export function validate(idNumber) {
+  const match = idNumber.match(/^(\d{8})([A-Z])$/);
+  if (!match) {
+    return false;
+  }
+  const [, digits, letter] = match;
+  const index = parseInt(digits, 10) % 23;
+  return MAGIC_LETTERS[index] === letter;
+}

--- a/js/test/esp.test.js
+++ b/js/test/esp.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { validate } from '../src/nationalid/esp/dni.js';
+
+test('valid DNI numbers', () => {
+  assert.strictEqual(validate('12345678Z'), true);
+  assert.strictEqual(validate('10469226V'), true);
+});
+
+test('invalid DNI numbers', () => {
+  assert.strictEqual(validate('1234567A'), false);
+  assert.strictEqual(validate('12345678A'), false);
+});


### PR DESCRIPTION
## Summary
- add Node.js project skeleton with Spain DNI validator
- include tests for valid and invalid Spain DNI numbers

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b421cafce48332abd0b15f8402a199