### PR TITLE
feat(js): expand national ID validation coverage

### DIFF
--- a/js/src/nationalid/alb/identity_number.js
+++ b/js/src/nationalid/alb/identity_number.js
@@ -1,0 +1,72 @@
+import { Gender } from '../constant.js';
+import { aliasOf } from '../util.js';
+
+const BASE_YEAR_MAP = '0123456789ABCDEFGHIJKLMNOPQRST';
+const REGEXP = /^(?<yy>[0-9A-T]\d)(?<mm>\d{2})(?<dd>\d{2})(?<sn>\d{3})[ -]?(?<checksum>[A-W])$/;
+
+export class IdentityNumber {
+  static METADATA = {
+    iso3166_alpha2: 'AL',
+    min_length: 10,
+    max_length: 10,
+    parsable: true,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: [
+      'Albania Identity Number',
+      'Numri i Identitetit',
+      'NID',
+      'Numri i Identitetit të Shtetasit',
+      'NISH',
+      'NIPT',
+    ],
+    links: ['https://en.wikipedia.org/wiki/National_identification_number#Albania'],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!idNumber || typeof idNumber !== 'string') {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const yy = match.groups.yy;
+    const mm = Number(match.groups.mm);
+    const dd = Number(match.groups.dd);
+    const yyyy = this.getYear(yy);
+    const month = mm < 50 ? mm : mm - 50;
+    const gender = mm < 50 ? Gender.MALE : Gender.FEMALE;
+
+    const dateObj = new Date(Date.UTC(yyyy, month - 1, dd));
+    if (
+      dateObj.getUTCFullYear() !== yyyy ||
+      dateObj.getUTCMonth() + 1 !== month ||
+      dateObj.getUTCDate() !== dd
+    ) {
+      return null;
+    }
+    return {
+      yyyymmdd: dateObj,
+      gender,
+      sn: match.groups.sn,
+      checksum: match.groups.checksum,
+    };
+  }
+
+  static getYear(yy) {
+    const base = 1800 + BASE_YEAR_MAP.indexOf(yy[0]) * 10;
+    return base + Number(yy[1]);
+  }
+}
+
+export const NationalID = aliasOf(IdentityNumber);
+export const NISH = aliasOf(IdentityNumber);
+export const NIPT = aliasOf(IdentityNumber);
+export const NID = aliasOf(IdentityNumber);

--- a/js/src/nationalid/are/emirates_id.js
+++ b/js/src/nationalid/are/emirates_id.js
@@ -1,0 +1,58 @@
+import { aliasOf } from '../util.js';
+import { luhnDigit, validateRegexp } from '../util.js';
+
+const REGEXP = /^784[ -]?(?<yyyy>\d{4})[ -]?(?<sn>\d{7})[ -]?(?<checksum>\d)$/;
+
+export class EmiratesIDNumber {
+  static METADATA = {
+    iso3166_alpha2: 'AE',
+    min_length: 15,
+    max_length: 15,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['Emirates ID', 'Resident ID', 'رقم الهوية'],
+    links: ['https://en.wikipedia.org/wiki/National_identification_number#United_Arab_Emirates'],
+    deprecated: false,
+  };
+
+  static normalize(idNumber) {
+    return idNumber.replace(/[ \-/]/g, '');
+  }
+
+  static validate(idNumber) {
+    if (!idNumber || typeof idNumber !== 'string') {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const checksum = this.checksum(idNumber);
+    if (checksum === null || checksum !== Number(match.groups.checksum)) {
+      return null;
+    }
+    return {
+      yyyy: Number(match.groups.yyyy),
+      sn: match.groups.sn,
+      checksum,
+    };
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return null;
+    }
+    const digits = this.normalize(idNumber)
+      .split('')
+      .map((d) => Number(d));
+    return luhnDigit(digits.slice(0, -1));
+  }
+}
+
+export const NationalID = aliasOf(EmiratesIDNumber);

--- a/js/src/nationalid/bgd/national_id.js
+++ b/js/src/nationalid/bgd/national_id.js
@@ -1,0 +1,45 @@
+import { validateRegexp } from '../util.js';
+import { OldNationalID } from './old_national_id.js';
+
+const REGEXP = /^(?<yyyy>\d{4})(?<distinct>\d{2})(?<rmo>\d)(?<police>\d{2})(?<union>\d{2})(?<sn>\d{6})$/;
+
+export class NationalID extends OldNationalID {
+  static METADATA = {
+    iso3166_alpha2: 'BD',
+    min_length: 13,
+    max_length: 13,
+    parsable: true,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['Bangladesh national ID number', 'জাতীয় পরিচয়পত্র', 'NID', 'BD'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identity_card_(Bangladesh)',
+      'http://nationalidcardbangladesh.blogspot.com/2016/04/voter-id-national-id-card-number.html',
+      'https://www.facebook.com/428195627559147/photos/a.428251897553520/428251617553548/?type=3',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const oldResult = OldNationalID.parse(idNumber.slice(4));
+    if (!oldResult) {
+      return null;
+    }
+    return {
+      ...oldResult,
+      yyyy: Number(match.groups.yyyy),
+    };
+  }
+}

--- a/js/src/nationalid/bgd/old_national_id.js
+++ b/js/src/nationalid/bgd/old_national_id.js
@@ -1,0 +1,64 @@
+import { validateRegexp } from '../util.js';
+
+export const ResidentialType = Object.freeze({
+  RURAL: 1,
+  MUNICIPALITY: 2,
+  CITY: 3,
+  OTHERS: 4,
+  CANTONMENT: 5,
+  CITY_CORPORATION: 9,
+});
+
+const REGEXP = /^(?<distinct>\d{2})(?<rmo>\d)(?<police>\d{2})(?<union>\d{2})(?<sn>\d{6})$/;
+const RMO_MAP = {
+  1: ResidentialType.RURAL,
+  2: ResidentialType.MUNICIPALITY,
+  3: ResidentialType.CITY,
+  4: ResidentialType.OTHERS,
+  5: ResidentialType.CANTONMENT,
+  9: ResidentialType.CITY_CORPORATION,
+};
+
+export class OldNationalID {
+  static METADATA = {
+    iso3166_alpha2: 'BD',
+    min_length: 13,
+    max_length: 13,
+    parsable: true,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['Bangladesh national ID number', 'জাতীয় পরিচয়পত্র', 'NID', 'BD'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identity_card_(Bangladesh)',
+      'http://nationalidcardbangladesh.blogspot.com/2016/04/voter-id-national-id-card-number.html',
+      'https://www.facebook.com/428195627559147/photos/a.428251897553520/428251617553548/?type=3',
+    ],
+    deprecated: true,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const rmo = Number(match.groups.rmo);
+    if (!(rmo in RMO_MAP)) {
+      return null;
+    }
+    return {
+      distinct: match.groups.distinct,
+      residential_type: RMO_MAP[rmo],
+      policy_station_no: match.groups.police,
+      union_code: match.groups.union,
+      sn: match.groups.sn,
+    };
+  }
+}

--- a/js/src/nationalid/egy/national_id.js
+++ b/js/src/nationalid/egy/national_id.js
@@ -1,0 +1,69 @@
+import { Gender } from '../constant.js';
+import { luhnDigit, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<century>[23])(?<yy>\d{2})(?<mm>\d{2})(?<dd>\d{2})(?<gov>\d{2})(?<sn>\d{4})(?<checksum>\d)$/;
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'EG',
+    min_length: 14,
+    max_length: 14,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number', 'الرقم القومي'],
+    links: ['https://en.wikipedia.org/wiki/National_identification_number#Egypt'],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const century = match.groups.century;
+    const yy = Number(match.groups.yy);
+    const mm = Number(match.groups.mm);
+    const dd = Number(match.groups.dd);
+    const yyyy = (century === '2' ? 1900 : 2000) + yy;
+    const dateObj = new Date(Date.UTC(yyyy, mm - 1, dd));
+    if (
+      dateObj.getUTCFullYear() !== yyyy ||
+      dateObj.getUTCMonth() + 1 !== mm ||
+      dateObj.getUTCDate() !== dd
+    ) {
+      return null;
+    }
+    const sn = match.groups.sn;
+    const checksum = this.checksum(idNumber);
+    if (checksum === null || checksum !== Number(match.groups.checksum)) {
+      return null;
+    }
+    return {
+      yyyymmdd: dateObj,
+      governorate: match.groups.gov,
+      sn,
+      gender: Number(sn[3]) % 2 === 1 ? Gender.MALE : Gender.FEMALE,
+      checksum,
+    };
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return null;
+    }
+    const digits = idNumber
+      .slice(0, -1)
+      .split('')
+      .map((d) => Number(d));
+    return luhnDigit(digits);
+  }
+}

--- a/js/src/nationalid/ind/national_id.js
+++ b/js/src/nationalid/ind/national_id.js
@@ -1,0 +1,42 @@
+import { aliasOf } from '../util.js';
+import { validateRegexp, verhoeffCheck } from '../util.js';
+
+const REGEXP = /^[2-9]\d{3}[ -]?\d{4}[ -]?\d{4}$/;
+
+function normalize(idNumber) {
+  return idNumber.replace(/[ -]/g, '');
+}
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'IN',
+    min_length: 12,
+    max_length: 12,
+    parsable: false,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number', 'Unique Identification Number', 'UID'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#India',
+      'https://archive.org/details/Aadhaar_numbering_scheme/page/n12/mode/1up?view=theater',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    return this.checksum(idNumber);
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    const digits = normalize(idNumber)
+      .split('')
+      .map((d) => Number(d));
+    return verhoeffCheck(digits);
+  }
+}
+
+export const UID = aliasOf(NationalID);

--- a/js/src/nationalid/irn/national_id.js
+++ b/js/src/nationalid/irn/national_id.js
@@ -1,0 +1,50 @@
+import { validateRegexp, weightedModulusDigit } from '../util.js';
+
+const REGEXP = /^\d{3}-?\d{6}-?\d$/;
+const MULTIPLIER = [10, 9, 8, 7, 6, 5, 4, 3, 2];
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'IR',
+    min_length: 10,
+    max_length: 10,
+    parsable: false,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number', 'kart-e-meli', 'کارت ملی'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#Iran,_Islamic_Republic_of',
+    ],
+    deprecated: false,
+  };
+
+  static normalize(idNumber) {
+    return idNumber.replace(/-/g, '');
+  }
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    const normalized = this.normalize(idNumber);
+    const checksum = this.checksum(idNumber);
+    return checksum !== null && checksum === Number(normalized.slice(-1));
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return null;
+    }
+    const digits = this.normalize(idNumber)
+      .split('')
+      .map((d) => Number(d));
+    const modulus = weightedModulusDigit(
+      digits.slice(0, -1),
+      MULTIPLIER,
+      11,
+      true,
+    );
+    return modulus < 2 ? modulus : 11 - modulus;
+  }
+}

--- a/js/src/nationalid/nga/national_id.js
+++ b/js/src/nationalid/nga/national_id.js
@@ -1,0 +1,22 @@
+import { validateRegexp } from '../util.js';
+
+const REGEXP = /^\d{11}$/;
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'NG',
+    min_length: 11,
+    max_length: 11,
+    parsable: false,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National Identification Number', 'NIN'],
+    links: ['https://en.wikipedia.org/wiki/National_identification_number#Nigeria'],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    return validateRegexp(idNumber, REGEXP);
+  }
+}

--- a/js/src/nationalid/pak/national_id.js
+++ b/js/src/nationalid/pak/national_id.js
@@ -1,0 +1,46 @@
+import { Gender } from '../constant.js';
+import { aliasOf, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<location>\d{5})-?(?<sn>\d{7})-?(?<gender>\d)$/;
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'PK',
+    min_length: 13,
+    max_length: 13,
+    parsable: true,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Card Number', 'CNIC', 'NIC', 'قومی شناختی کارڈ'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#Pakistan',
+      'https://en.wikipedia.org/wiki/CNIC_(Pakistan)#Security_features',
+      'https://www.geo.tv/latest/250118-mystery-behind-13-digit-cnic-number',
+      'https://www.informationpk.com/interesting-information-about-or-meaning-of-nadra-cnic-13-digits-number/',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    return {
+      location: match.groups.location,
+      sn: match.groups.sn,
+      gender:
+        Number(match.groups.gender) % 2 === 1 ? Gender.MALE : Gender.FEMALE,
+    };
+  }
+}
+
+export const CNIC = aliasOf(NationalID);

--- a/js/src/nationalid/phl/phil_id.js
+++ b/js/src/nationalid/phl/phil_id.js
@@ -1,0 +1,27 @@
+import { aliasOf, validateRegexp } from '../util.js';
+
+const REGEXP = /^(\d{4}[ -]?\d{7}[ -]?\d)$/;
+
+export class PhilID {
+  static METADATA = {
+    iso3166_alpha2: 'PH',
+    min_length: 12,
+    max_length: 12,
+    parsable: false,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['PhilID Card Number', 'PCN', 'PhilSys'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#Philippines',
+      'https://en.wikipedia.org/wiki/Philippine_national_identity_card',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    return validateRegexp(idNumber, REGEXP);
+  }
+}
+
+export const NationalID = aliasOf(PhilID);

--- a/js/test/alb.test.js
+++ b/js/test/alb.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { IdentityNumber, NationalID } from '../src/nationalid/alb/identity_number.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid NID numbers', () => {
+  assert.strictEqual(IdentityNumber.validate('I90308094A'), true);
+});
+
+test('invalid NID numbers', () => {
+  assert.strictEqual(IdentityNumber.validate('Z90308094Z'), false);
+});
+
+test('parse NID', () => {
+  const result = IdentityNumber.parse('I90308094A');
+  assert.ok(result);
+  assert.strictEqual(result.yyyymmdd.getUTCFullYear(), 1989);
+  assert.strictEqual(result.yyyymmdd.getUTCMonth() + 1, 3);
+  assert.strictEqual(result.yyyymmdd.getUTCDate(), 8);
+  assert.strictEqual(result.sn, '094');
+  assert.strictEqual(result.checksum, 'A');
+  assert.strictEqual(result.gender, Gender.MALE);
+});
+
+test('alias of', () => {
+  assert.strictEqual(IdentityNumber.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, IdentityNumber);
+});

--- a/js/test/are.test.js
+++ b/js/test/are.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { EmiratesIDNumber, NationalID } from '../src/nationalid/are/emirates_id.js';
+
+test('valid Emirates ID numbers', () => {
+  assert.strictEqual(EmiratesIDNumber.validate('784-1980-1234567-8'), true);
+  assert.strictEqual(EmiratesIDNumber.validate('784198012345678'), true);
+  assert.strictEqual(EmiratesIDNumber.validate('784-1979-1234567-1'), true);
+  assert.strictEqual(EmiratesIDNumber.validate('784-1952-0464048-6'), true);
+  assert.strictEqual(EmiratesIDNumber.validate('784-1968-6570305-0'), true);
+});
+
+test('invalid Emirates ID numbers', () => {
+  assert.strictEqual(EmiratesIDNumber.validate('784-1981-1234567-9'), false);
+  assert.strictEqual(EmiratesIDNumber.validate('784198212345679'), false);
+  assert.strictEqual(EmiratesIDNumber.validate('784-199234567-1'), false);
+  assert.strictEqual(EmiratesIDNumber.validate('784-2002-12345'), false);
+});
+
+test('parse Emirates ID', () => {
+  const result = EmiratesIDNumber.parse('784-1968-6570305-0');
+  assert.ok(result);
+  assert.strictEqual(result.yyyy, 1968);
+  assert.strictEqual(result.sn, '6570305');
+  assert.strictEqual(result.checksum, 0);
+});
+
+test('alias of', () => {
+  assert.strictEqual(EmiratesIDNumber.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, EmiratesIDNumber);
+});

--- a/js/test/bgd.test.js
+++ b/js/test/bgd.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { OldNationalID, ResidentialType } from '../src/nationalid/bgd/old_national_id.js';
+import { NationalID } from '../src/nationalid/bgd/national_id.js';
+
+test('valid Bangladesh IDs', () => {
+  assert.strictEqual(OldNationalID.validate('1592824588424'), true);
+  assert.strictEqual(OldNationalID.validate('2610413965404'), true);
+  assert.strictEqual(NationalID.validate('19841592824588424'), true);
+  assert.strictEqual(NationalID.validate('19892610413965404'), true);
+});
+
+test('invalid Bangladesh IDs', () => {
+  assert.strictEqual(OldNationalID.validate('159282458842'), false);
+  assert.strictEqual(OldNationalID.validate('1572824588424'), false);
+  assert.strictEqual(NationalID.validate('1984159282458844'), false);
+});
+
+test('parse old Bangladesh ID', () => {
+  const result = OldNationalID.parse('1592824588424');
+  assert.ok(result);
+  assert.strictEqual(result.distinct, '15');
+  assert.strictEqual(result.residential_type, ResidentialType.CITY_CORPORATION);
+  assert.strictEqual(result.policy_station_no, '28');
+  assert.strictEqual(result.union_code, '24');
+  assert.strictEqual(result.sn, '588424');
+});
+
+test('parse new Bangladesh ID', () => {
+  const result = NationalID.parse('19892610413965404');
+  assert.ok(result);
+  assert.strictEqual(result.yyyy, 1989);
+  assert.strictEqual(result.distinct, '26');
+  assert.strictEqual(result.residential_type, ResidentialType.RURAL);
+  assert.strictEqual(result.policy_station_no, '04');
+  assert.strictEqual(result.union_code, '13');
+  assert.strictEqual(result.sn, '965404');
+});

--- a/js/test/egy.test.js
+++ b/js/test/egy.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/nationalid/egy/national_id.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid Egyptian ID numbers', () => {
+  assert.strictEqual(NationalID.validate('29001010100015'), true);
+});
+
+test('invalid Egyptian ID numbers', () => {
+  assert.strictEqual(NationalID.validate('29001010100014'), false);
+});
+
+test('parse Egyptian ID', () => {
+  const result = NationalID.parse('29001010100015');
+  assert.ok(result);
+  assert.strictEqual(result.yyyymmdd.getUTCFullYear(), 1990);
+  assert.strictEqual(result.yyyymmdd.getUTCMonth() + 1, 1);
+  assert.strictEqual(result.yyyymmdd.getUTCDate(), 1);
+  assert.strictEqual(result.governorate, '01');
+  assert.strictEqual(result.sn, '0001');
+  assert.strictEqual(result.gender, Gender.MALE);
+  assert.strictEqual(result.checksum, 5);
+});

--- a/js/test/ind.test.js
+++ b/js/test/ind.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID, UID } from '../src/nationalid/ind/national_id.js';
+
+test('valid UID numbers', () => {
+  assert.strictEqual(NationalID.validate('8924 7352 8038'), true);
+  assert.strictEqual(NationalID.validate('3977 8800 0234'), true);
+  assert.strictEqual(NationalID.validate('5485-5000-8800'), true);
+  assert.strictEqual(NationalID.validate('475587669949'), true);
+});
+
+test('invalid UID numbers', () => {
+  assert.strictEqual(NationalID.validate('47558'), false);
+  assert.strictEqual(NationalID.validate('475587669940'), false);
+  assert.strictEqual(NationalID.validate('175587669949'), false);
+});
+
+test('alias of', () => {
+  assert.strictEqual(NationalID.METADATA.alias_of, null);
+  assert.strictEqual(UID.METADATA.alias_of, NationalID);
+});

--- a/js/test/irn.test.js
+++ b/js/test/irn.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/nationalid/irn/national_id.js';
+
+test('valid Iran national ID numbers', () => {
+  assert.strictEqual(NationalID.validate('472-171992-2'), true);
+  assert.strictEqual(NationalID.validate('4608968882'), true);
+  assert.strictEqual(NationalID.validate('1111111111'), true);
+  assert.strictEqual(NationalID.validate('0939092001'), true);
+});
+
+test('invalid Iran national ID numbers', () => {
+  assert.strictEqual(NationalID.validate('472-171992-1'), false);
+  assert.strictEqual(NationalID.validate('2130396217'), false);
+  assert.strictEqual(NationalID.validate('0000000001'), false);
+  assert.strictEqual(NationalID.validate('abcd1234'), false);
+});

--- a/js/test/nga.test.js
+++ b/js/test/nga.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/nationalid/nga/national_id.js';
+
+test('valid NIN numbers', () => {
+  assert.strictEqual(NationalID.validate('12345678901'), true);
+});
+
+test('invalid NIN numbers', () => {
+  assert.strictEqual(NationalID.validate('1234567890A'), false);
+});
+
+test('with regexp', () => {
+  assert.match('12345678901', NationalID.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NationalID.METADATA);
+});

--- a/js/test/pak.test.js
+++ b/js/test/pak.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID, CNIC } from '../src/nationalid/pak/national_id.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid CNIC numbers', () => {
+  assert.strictEqual(NationalID.validate('57469-0532456-7'), true);
+  assert.strictEqual(NationalID.validate('0975345678053'), true);
+  assert.strictEqual(NationalID.validate('0975431479567'), true);
+  assert.strictEqual(NationalID.validate('73654-8723402-3'), true);
+  assert.strictEqual(NationalID.validate('2374982638947'), true);
+  assert.strictEqual(NationalID.validate('26349-6293643-8'), true);
+});
+
+test('invalid CNIC numbers', () => {
+  assert.strictEqual(NationalID.validate('57469-0532456'), false);
+});
+
+test('parse CNIC', () => {
+  const result = NationalID.parse('57469-0532456-7');
+  assert.ok(result);
+  assert.strictEqual(result.location, '57469');
+  assert.strictEqual(result.sn, '0532456');
+  assert.strictEqual(result.gender, Gender.MALE);
+});
+
+test('alias of', () => {
+  assert.strictEqual(NationalID.METADATA.alias_of, null);
+  assert.strictEqual(CNIC.METADATA.alias_of, NationalID);
+});

--- a/js/test/phl.test.js
+++ b/js/test/phl.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { PhilID, NationalID } from '../src/nationalid/phl/phil_id.js';
+
+test('valid PhilID numbers', () => {
+  assert.strictEqual(PhilID.validate('1234-5678912-3'), true);
+  assert.strictEqual(PhilID.validate('123456789123'), true);
+});
+
+test('invalid PhilID numbers', () => {
+  assert.strictEqual(PhilID.validate('1234567890'), false);
+});
+
+test('alias of', () => {
+  assert.strictEqual(PhilID.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, PhilID);
+});


### PR DESCRIPTION
## Summary
- add United Arab Emirates EmiratesIDNumber with Luhn checksum and alias exports
- implement national ID validators for India, Pakistan, Philippines, Bangladesh (old & new), Egypt, Nigeria, Albania, and Iran
- cover all new validators with parsing and validation tests

## Testing
- `npm test --prefix js`


------
https://chatgpt.com/codex/tasks/task_e_68b42dbc39608332a8ed419096c2532c