### PR TITLE
feat(js): add China resident ID parser

### DIFF
--- a/js/src/nationalid/chn/resident_id.js
+++ b/js/src/nationalid/chn/resident_id.js
@@ -1,0 +1,86 @@
+import { Gender } from '../constant.js';
+import { aliasOf, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<address_code>\d{6})(?<yyyy>\d{4})(?<mm>0[1-9]|1[0-2])(?<dd>0[1-9]|[12][0-9]|3[01])(?<sn>\d{3})(?<checksum>(\d|X))$/;
+
+function normalize(idNumber) {
+  return idNumber ? idNumber.toUpperCase() : null;
+}
+
+export class ResidentID {
+  static METADATA = {
+    iso3166_alpha2: 'CN',
+    min_length: 18,
+    max_length: 18,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: [
+      'Resident Identity Number',
+      '居民身份证',
+      'Jūmín Shēnfènzhèng',
+    ],
+    links: [
+      'https://en.wikipedia.org/wiki/Resident_Identity_Card',
+      'https://en.wikipedia.org/wiki/National_identification_number#China',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!idNumber || typeof idNumber !== 'string') {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const checksum = this.checksum(idNumber);
+    if (checksum === null || String(checksum) !== match.groups.checksum) {
+      return null;
+    }
+    const yyyy = Number(match.groups.yyyy);
+    const mm = Number(match.groups.mm);
+    const dd = Number(match.groups.dd);
+    const sn = match.groups.sn;
+    const dateObj = new Date(Date.UTC(yyyy, mm - 1, dd));
+    if (
+      dateObj.getUTCFullYear() !== yyyy ||
+      dateObj.getUTCMonth() + 1 !== mm ||
+      dateObj.getUTCDate() !== dd
+    ) {
+      return null;
+    }
+    return {
+      address_code: match.groups.address_code,
+      yyyymmdd: dateObj,
+      sn,
+      gender: Number(sn) % 2 === 0 ? Gender.FEMALE : Gender.MALE,
+      checksum,
+    };
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return null;
+    }
+    const normalized = normalize(idNumber);
+    const digits = normalized
+      .slice(0, -1)
+      .split('')
+      .map((c) => Number(c));
+    let total = 0;
+    for (let i = 0; i < digits.length; i++) {
+      total += digits[i] * (Math.pow(2, 17 - i) % 11);
+    }
+    const checksum = (12 - (total % 11)) % 11;
+    return checksum === 10 ? 'X' : checksum;
+  }
+}
+
+export const NationalID = aliasOf(ResidentID);

--- a/js/test/chn.test.js
+++ b/js/test/chn.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { ResidentID, NationalID } from '../src/nationalid/chn/resident_id.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid ResidentID numbers', () => {
+  assert.strictEqual(ResidentID.validate('11010219840406970X'), true);
+  assert.strictEqual(ResidentID.validate('440524188001010014'), true);
+  assert.strictEqual(ResidentID.validate('11010519491231002X'), true);
+});
+
+test('invalid ResidentID numbers', () => {
+  assert.strictEqual(ResidentID.validate('11010219840506970X'), false);
+  assert.strictEqual(ResidentID.validate('440524189001010014'), false);
+  assert.strictEqual(ResidentID.validate('11020519491231002X'), false);
+});
+
+test('parse ResidentID', () => {
+  const result = ResidentID.parse('11010219840406970X');
+  assert.ok(result);
+  assert.strictEqual(result.address_code, '110102');
+  assert.strictEqual(result.yyyymmdd.getUTCFullYear(), 1984);
+  assert.strictEqual(result.yyyymmdd.getUTCMonth() + 1, 4);
+  assert.strictEqual(result.yyyymmdd.getUTCDate(), 6);
+  assert.strictEqual(result.sn, '970');
+  assert.strictEqual(result.gender, Gender.FEMALE);
+  assert.strictEqual(result.checksum, 'X');
+
+  const result2 = ResidentID.parse('440524188001010014');
+  assert.ok(result2);
+  assert.strictEqual(result2.address_code, '440524');
+  assert.strictEqual(result2.yyyymmdd.getUTCFullYear(), 1880);
+  assert.strictEqual(result2.yyyymmdd.getUTCMonth() + 1, 1);
+  assert.strictEqual(result2.yyyymmdd.getUTCDate(), 1);
+  assert.strictEqual(result2.sn, '001');
+  assert.strictEqual(result2.gender, Gender.MALE);
+  assert.strictEqual(result2.checksum, 4);
+});
+
+test('alias of', () => {
+  assert.strictEqual(ResidentID.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, ResidentID);
+});


### PR DESCRIPTION
## Summary
- port China Resident Identity Card logic from Python to JS
- validate and parse IDs with checksum and gender detection
- add unit tests for Chinese ResidentID

## Testing
- `npm test`
- `pytest tests/nationalid/test_CHN.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4331db59c83328426d6498599c623