### PR TITLE
feat(js): add UK NINO and US SSN validators

### DIFF
--- a/js/src/nationalid/chn/resident_id.js
+++ b/js/src/nationalid/chn/resident_id.js
@@ -1,0 +1,86 @@
+import { Gender } from '../constant.js';
+import { aliasOf, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<address_code>\d{6})(?<yyyy>\d{4})(?<mm>0[1-9]|1[0-2])(?<dd>0[1-9]|[12][0-9]|3[01])(?<sn>\d{3})(?<checksum>(\d|X))$/;
+
+function normalize(idNumber) {
+  return idNumber ? idNumber.toUpperCase() : null;
+}
+
+export class ResidentID {
+  static METADATA = {
+    iso3166_alpha2: 'CN',
+    min_length: 18,
+    max_length: 18,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: [
+      'Resident Identity Number',
+      '居民身份证',
+      'Jūmín Shēnfènzhèng',
+    ],
+    links: [
+      'https://en.wikipedia.org/wiki/Resident_Identity_Card',
+      'https://en.wikipedia.org/wiki/National_identification_number#China',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!idNumber || typeof idNumber !== 'string') {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const checksum = this.checksum(idNumber);
+    if (checksum === null || String(checksum) !== match.groups.checksum) {
+      return null;
+    }
+    const yyyy = Number(match.groups.yyyy);
+    const mm = Number(match.groups.mm);
+    const dd = Number(match.groups.dd);
+    const sn = match.groups.sn;
+    const dateObj = new Date(Date.UTC(yyyy, mm - 1, dd));
+    if (
+      dateObj.getUTCFullYear() !== yyyy ||
+      dateObj.getUTCMonth() + 1 !== mm ||
+      dateObj.getUTCDate() !== dd
+    ) {
+      return null;
+    }
+    return {
+      address_code: match.groups.address_code,
+      yyyymmdd: dateObj,
+      sn,
+      gender: Number(sn) % 2 === 0 ? Gender.FEMALE : Gender.MALE,
+      checksum,
+    };
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return null;
+    }
+    const normalized = normalize(idNumber);
+    const digits = normalized
+      .slice(0, -1)
+      .split('')
+      .map((c) => Number(c));
+    let total = 0;
+    for (let i = 0; i < digits.length; i++) {
+      total += digits[i] * (Math.pow(2, 17 - i) % 11);
+    }
+    const checksum = (12 - (total % 11)) % 11;
+    return checksum === 10 ? 'X' : checksum;
+  }
+}
+
+export const NationalID = aliasOf(ResidentID);

--- a/js/src/nationalid/deu/tax_id.js
+++ b/js/src/nationalid/deu/tax_id.js
@@ -1,0 +1,86 @@
+import { aliasOf, validateRegexp, mnModulusDigit, modulusOverflowMod10 } from '../util.js';
+
+const REGEXP = /^\d{2} ?\d{3} ?\d{3} ?\d{3}$/;
+
+function normalize(idNumber) {
+  return idNumber.replace(/ /g, '');
+}
+
+export class TaxID {
+  static METADATA = {
+    iso3166_alpha2: 'DE',
+    min_length: 11,
+    max_length: 11,
+    parsable: false,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: [
+      'Tax ID',
+      'Steuerliche Identifikationsnummer',
+      'Persönliche Identificationsnummer',
+      'Identifikationsnummer',
+      'Steuer-IdNr.',
+      'IdNr',
+      'Steuer-ID',
+    ],
+    links: ['https://allaboutberlin.com/guides/german-tax-id-steuernummer'],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    if (!this.checkMultipleOccurrence(idNumber)) {
+      return false;
+    }
+    if (!this.checkConsecutivePosition(idNumber)) {
+      return false;
+    }
+    return this.checksum(idNumber);
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    const numbers = normalize(idNumber).split('').map((c) => Number(c));
+    const check = numbers.pop();
+    return check === this.getCheckdigit(numbers);
+  }
+
+  static getCheckdigit(numbers) {
+    return modulusOverflowMod10(mnModulusDigit(numbers, 10, 11));
+  }
+
+  static checkMultipleOccurrence(idNumber) {
+    const normalized = normalize(idNumber).slice(0, -1).split('').sort();
+    let firstMultiple = null;
+    for (let i = 1; i < normalized.length; i++) {
+      const digit = normalized[i];
+      if (!firstMultiple && digit === normalized[i - 1]) {
+        firstMultiple = digit;
+      } else if (digit === normalized[i - 1] && digit !== firstMultiple) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static checkConsecutivePosition(idNumber) {
+    const normalized = normalize(idNumber).split('');
+    for (let i = 0; i < normalized.length - 2; i++) {
+      if (
+        normalized[i] === normalized[i + 1] &&
+        normalized[i] === normalized[i + 2]
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+export const NationalID = aliasOf(TaxID);
+export const IdNr = aliasOf(TaxID);

--- a/js/src/nationalid/fra/insee.js
+++ b/js/src/nationalid/fra/insee.js
@@ -1,0 +1,80 @@
+import { Gender } from '../constant.js';
+import { aliasOf, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<gender>[123478])(?<yy>\d{2})(?<mm>(0[1-9]|1[0-2]|[2-3][0-9]|4[0-2]|[5-9][0-9]))(?<birth_department>((\d{2}|2[ABab])\d{3}))(?<cert_number>(?!000)\d{3})(?<control_key>(?!(00|98|99))\d{2})$/;
+
+function normalize(idNumber) {
+  return idNumber ? idNumber.toUpperCase() : null;
+}
+
+export class INSEE {
+  static METADATA = {
+    iso3166_alpha2: 'FR',
+    min_length: 15,
+    max_length: 15,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number', 'INSEE', 'NIR', 'NIRPP'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#France',
+      'https://fr.wikipedia.org/wiki/Num%C3%A9ro_de_s%C3%A9curit%C3%A9_sociale_en_France#Signification_des_chiffres_du_NIR',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = normalize(idNumber).match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const birthDepartment = this.validateBirthDepartment(match.groups.birth_department);
+    if (!birthDepartment) {
+      return null;
+    }
+    const checksum = this.checksum(idNumber);
+    if (checksum === null || String(checksum) !== match.groups.control_key) {
+      return null;
+    }
+    return {
+      gender: match.groups.gender === '1' ? Gender.MALE : Gender.FEMALE,
+      yy: match.groups.yy,
+      mm: match.groups.mm,
+      birth_department: birthDepartment,
+      checksum: match.groups.control_key,
+    };
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return null;
+    }
+    const normalized = normalize(idNumber).replace('2A', '19').replace('2B', '18');
+    return 97 - (Number(normalized.slice(0, -2)) % 97);
+  }
+
+  static validateBirthDepartment(birthDepartment) {
+    const departmentCode = birthDepartment.slice(0, 2).toUpperCase();
+    if ((/^[0-9]{2}$/.test(departmentCode) && Number(departmentCode) >= 1 && Number(departmentCode) <= 95) || ['2A', '2B'].includes(departmentCode)) {
+      return { department: birthDepartment.slice(0, 2), city: birthDepartment.slice(2), country: '' };
+    }
+    const numeric = Number(departmentCode);
+    if (numeric >= 97 && numeric <= 98) {
+      return { department: birthDepartment.slice(0, 3), city: birthDepartment.slice(3), country: '' };
+    }
+    if (departmentCode === '99') {
+      return { department: '', city: '', country: birthDepartment.slice(2) };
+    }
+    return null;
+  }
+}
+
+export const NationalID = aliasOf(INSEE);

--- a/js/src/nationalid/gbr/national_insurance.js
+++ b/js/src/nationalid/gbr/national_insurance.js
@@ -1,0 +1,49 @@
+import { validateRegexp, aliasOf } from '../util.js';
+
+const REGEXP = /^[A-Z]{2}\d{6}[A-Z]$/;
+
+function checkPrefix(prefix) {
+  const prohibitChars = ['D', 'F', 'I', 'Q', 'U', 'V'];
+  if (prohibitChars.some((c) => prefix.includes(c))) {
+    return false;
+  }
+  if (prefix[1] === 'O') {
+    return false;
+  }
+  const notAllocated = ['BG', 'GB', 'NK', 'KN', 'TN', 'NT', 'ZZ'];
+  return !notAllocated.includes(prefix);
+}
+
+function checkSuffix(suffix) {
+  const allowed = ['A', 'B', 'C', 'D', 'F', 'M', 'P'];
+  return allowed.includes(suffix);
+}
+
+export class NationalInsuranceNumber {
+  static METADATA = {
+    iso3166_alpha2: 'GB',
+    min_length: 9,
+    max_length: 9,
+    parsable: false,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National Insurance Number', 'NI No', 'NINO'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_Insurance_number',
+      'https://www.gov.uk/hmrc-internal-manuals/national-insurance-manual/nim39110',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    const prefix = idNumber.slice(0, 2);
+    const suffix = idNumber.slice(-1);
+    return checkPrefix(prefix) && checkSuffix(suffix);
+  }
+}
+
+export const NationalID = aliasOf(NationalInsuranceNumber);

--- a/js/src/nationalid/idn/national_id.js
+++ b/js/src/nationalid/idn/national_id.js
@@ -1,0 +1,63 @@
+import { Gender } from '../constant.js';
+import { aliasOf, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<district>\d{6})(?<dd>[0-7]\d)(?<mm>(0[1-9]|1[012]))(?<yy>\d{2})(?!0000)\d{4}$/;
+const DISTRICT = ['710510'];
+
+export class NIK {
+  static METADATA = {
+    iso3166_alpha2: 'ID',
+    min_length: 16,
+    max_length: 16,
+    parsable: true,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['ID Number', 'NIK', 'Nomor Induk Kependudukan'],
+    links: ['https://en.wikipedia.org/wiki/National_identification_number#Indonesia'],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const district = match.groups.district;
+    if (!DISTRICT.includes(district)) {
+      return null;
+    }
+    const gender = Number(match.groups.dd[0]) <= 3 ? Gender.FEMALE : Gender.MALE;
+    const yy = match.groups.yy;
+    const mm = match.groups.mm;
+    const ddVal = gender === Gender.FEMALE ? match.groups.dd : String(Number(match.groups.dd) - 30).padStart(2, '0');
+    try {
+      const yyyy = Number(`20${yy}`);
+      const dateObj = new Date(Date.UTC(yyyy, Number(mm) - 1, Number(ddVal)));
+      if (
+        dateObj.getUTCMonth() + 1 !== Number(mm) ||
+        dateObj.getUTCDate() !== Number(ddVal)
+      ) {
+        return null;
+      }
+    } catch {
+      return null;
+    }
+    return {
+      gender,
+      yy,
+      mm,
+      dd: String(ddVal).padStart(2, '0'),
+      district,
+    };
+  }
+}
+
+export const NationalID = aliasOf(NIK);

--- a/js/src/nationalid/ita/fiscal_code.js
+++ b/js/src/nationalid/ita/fiscal_code.js
@@ -1,0 +1,131 @@
+import { Gender } from '../constant.js';
+import { aliasOf, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<surname>[A-Z]{3})(?<firstname>[A-Z]{3})(?<yy>[0-9A-Z]{2})(?<m>[A-EHLMPR-T])(?<dd>[0-9A-Z]{2})(?<area_code>[A-Z][0-9A-Z]{3})(?<checksum>[A-Z])$/;
+
+const MONTH_MAP = { A:1, B:2, C:3, D:4, E:5, H:6, L:7, M:8, P:9, R:10, S:11, T:12 };
+const MAGIC_ODD_CHAR_MAP = { '0':1,'9':21,'I':19,'R':8,'1':0,'A':1,'J':21,'S':12,'2':5,'B':0,'K':2,'T':14,'3':7,'C':5,'L':4,'U':16,'4':9,'D':7,'M':18,'V':10,'5':13,'E':9,'N':20,'W':22,'6':15,'F':13,'O':11,'X':25,'7':17,'G':15,'P':3,'Y':24,'8':19,'H':17,'Q':6,'Z':23 };
+const MAGIC_EVEN_CHAR_MAP = { '0':0,'9':9,'I':8,'R':17,'1':1,'A':0,'J':9,'S':18,'2':2,'B':1,'K':10,'T':19,'3':3,'C':2,'L':11,'U':20,'4':4,'D':3,'M':12,'V':21,'5':5,'E':4,'N':13,'W':22,'6':6,'F':5,'O':14,'X':23,'7':7,'G':6,'P':15,'Y':24,'8':8,'H':7,'Q':16,'Z':25 };
+const NUMERIC_REPLACEMENT = { L:'0', Q:'4', U:'8', M:'1', R:'5', V:'9', N:'2', S:'6', P:'3', T:'7' };
+
+export class FiscalCode {
+  static METADATA = {
+    iso3166_alpha2: 'IT',
+    min_length: 16,
+    max_length: 16,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['Fiscal Code', 'Codice fiscale'],
+    links: [
+      'https://en.wikipedia.org/wiki/Italian_fiscal_code',
+      'https://en.wikipedia.org/wiki/National_identification_number#Italy',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!idNumber || typeof idNumber !== 'string') {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const areaCodeNums = this.sterilizeNumbers(match.groups.area_code.slice(1));
+    if (!areaCodeNums) {
+      return null;
+    }
+    const dobGender = this.extractBirthday(match.groups.yy, match.groups.m, match.groups.dd);
+    if (!dobGender) {
+      return null;
+    }
+    const checksum = this.checksum(idNumber);
+    if (checksum === null || checksum !== match.groups.checksum) {
+      return null;
+    }
+    return {
+      surname_consonants: match.groups.surname,
+      firstname_consonants: match.groups.firstname,
+      area_code: match.groups.area_code[0] + areaCodeNums,
+      yyyymmdd: dobGender.date,
+      gender: dobGender.gender,
+      checksum,
+    };
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return null;
+    }
+    const alphanum = idNumber.slice(0, -1);
+    let odd = 0;
+    let even = 0;
+    for (let i = 0; i < alphanum.length; i++) {
+      const ch = alphanum[i];
+      if ((i + 1) % 2 === 1) {
+        odd += MAGIC_ODD_CHAR_MAP[ch];
+      } else {
+        even += MAGIC_EVEN_CHAR_MAP[ch];
+      }
+    }
+    const modulus = (odd + even) % 26;
+    return String.fromCharCode(65 + modulus);
+  }
+
+  static extractBirthday(yyStr, m, ddStr) {
+    if (!(m in MONTH_MAP)) {
+      return null;
+    }
+    const sterilizedDd = this.sterilizeNumbers(ddStr);
+    if (!sterilizedDd) {
+      return null;
+    }
+    const sterilizedYy = this.sterilizeNumbers(yyStr);
+    if (!sterilizedYy) {
+      return null;
+    }
+    const yy = Number(sterilizedYy);
+    const dd = Number(sterilizedDd);
+    const yearBase = yy < 50 ? 2000 : 1900;
+    const mm = MONTH_MAP[m];
+    const day = dd < 40 ? dd : dd - 40;
+    const gender = dd < 40 ? Gender.MALE : Gender.FEMALE;
+    try {
+      const dateObj = new Date(Date.UTC(yearBase + yy, mm - 1, day));
+      if (
+        dateObj.getUTCFullYear() !== yearBase + yy ||
+        dateObj.getUTCMonth() + 1 !== mm ||
+        dateObj.getUTCDate() !== day
+      ) {
+        return null;
+      }
+      return { date: dateObj, gender };
+    } catch {
+      return null;
+    }
+  }
+
+  static sterilizeNumbers(source) {
+    let result = '';
+    for (let i = source.length - 1; i >= 0; i--) {
+      const char = source[i];
+      if (/[A-Z]/.test(char)) {
+        if (!(char in NUMERIC_REPLACEMENT)) {
+          return null;
+        }
+        result += NUMERIC_REPLACEMENT[char];
+      } else {
+        result += char;
+      }
+    }
+    return result.split('').reverse().join('');
+  }
+}
+
+export const NationalID = aliasOf(FiscalCode);

--- a/js/src/nationalid/lka/national_id.js
+++ b/js/src/nationalid/lka/national_id.js
@@ -1,0 +1,66 @@
+import { Gender } from '../constant.js';
+import { validateRegexp, weightedModulusDigit, modulusOverflowMod10 } from '../util.js';
+
+const REGEXP = /^(?<year>\d{4})(?<days>\d{3})(?<sn>\d{4})(?<checksum>\d)$/;
+const MAGIC_MULTIPLIER = [8, 4, 3, 2, 7, 6, 5, 7, 4, 3, 2];
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'LK',
+    min_length: 12,
+    max_length: 12,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#Sri_Lanka',
+      'https://drp.gov.lk/Templates/Artical%20-%20English%20new%20number.html',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const year = Number(match.groups.year);
+    const days = Number(match.groups.days);
+    const sn = match.groups.sn;
+    if (!this.checksum(idNumber)) {
+      return null;
+    }
+    try {
+      const dateObj = new Date(Date.UTC(year, 0, 1));
+      dateObj.setUTCDate(dateObj.getUTCDate() + (days > 500 ? days - 501 : days - 1));
+      return {
+        yyyymmdd: dateObj,
+        gender: days < 500 ? Gender.MALE : Gender.FEMALE,
+        sn,
+        checksum: Number(match.groups.checksum),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    const numbers = idNumber.split('').map((c) => Number(c));
+    const modulus = modulusOverflowMod10(
+      weightedModulusDigit(numbers.slice(0, -1), MAGIC_MULTIPLIER, 11)
+    );
+    return modulus === numbers[numbers.length - 1];
+  }
+}

--- a/js/src/nationalid/lka/old_national_id.js
+++ b/js/src/nationalid/lka/old_national_id.js
@@ -1,0 +1,63 @@
+import { Citizenship } from '../constant.js';
+import { NationalID } from './national_id.js';
+import { validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<year>\d{2})(?<days>\d{3})(?<sn>\d{3})(?<checksum>\d)(?<citizenship>[XxVv])$/;
+
+export class OldNationalID {
+  static METADATA = {
+    iso3166_alpha2: 'LK',
+    min_length: 10,
+    max_length: 10,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#Sri_Lanka',
+      'https://drp.gov.lk/Templates/Artical%20-%20English%20new%20number.html',
+    ],
+    deprecated: true,
+  };
+
+  static toNew(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const { year, days, sn, checksum } = match.groups;
+    return `19${year}${days}0${sn}${checksum}`;
+  }
+
+  static validate(idNumber) {
+    if (!idNumber || typeof idNumber !== 'string') {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const newId = this.toNew(idNumber);
+    if (!newId) {
+      return null;
+    }
+    const result = NationalID.parse(newId);
+    if (!result) {
+      return null;
+    }
+    const citizenship =
+      idNumber.slice(-1).toUpperCase() === 'V'
+        ? Citizenship.CITIZEN
+        : Citizenship.RESIDENT;
+    return { ...result, citizenship };
+  }
+
+  static checksum(idNumber) {
+    const newId = this.toNew(idNumber);
+    if (!newId) {
+      return false;
+    }
+    return NationalID.checksum(newId);
+  }
+}

--- a/js/src/nationalid/mys/nric.js
+++ b/js/src/nationalid/mys/nric.js
@@ -1,0 +1,65 @@
+import { Citizenship } from '../constant.js';
+import { aliasOf, validateRegexp } from '../util.js';
+
+const REGEXP = /^(?<yy>\d{2})(?<mm>\d{2})(?<dd>\d{2})-?(?<pb>\d{2})-?(?<sn>\d{4})$/;
+const WRONG_PB_CODE = ['00','17','18','19','20','69','70','73','80','81','94','95','96','97'];
+
+export class NRIC {
+  static METADATA = {
+    iso3166_alpha2: 'MY',
+    min_length: 12,
+    max_length: 12,
+    parsable: true,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National Registration Identity Card Number', 'NRIC'],
+    links: [
+      'https://en.wikipedia.org/wiki/Malaysian_identity_card#Structure_of_the_National_Registration_Identity_Card_Number_(NRIC)'
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const yy = Number(match.groups.yy);
+    const mm = Number(match.groups.mm);
+    const dd = Number(match.groups.dd);
+    const location = match.groups.pb;
+    if (WRONG_PB_CODE.includes(location)) {
+      return null;
+    }
+    const sn = match.groups.sn;
+    const yyyyBase = Number(sn[0]) > 4 ? 1900 : 2000;
+    try {
+      const dateObj = new Date(Date.UTC(yyyyBase + yy, mm - 1, dd));
+      if (
+        dateObj.getUTCFullYear() !== yyyyBase + yy ||
+        dateObj.getUTCMonth() + 1 !== mm ||
+        dateObj.getUTCDate() !== dd
+      ) {
+        return null;
+      }
+      return {
+        yyyymmdd: dateObj,
+        location,
+        citizenship: Number(location) < 60 ? Citizenship.CITIZEN : Citizenship.RESIDENT,
+        sn,
+      };
+    } catch {
+      return null;
+    }
+  }
+}
+
+export const NationalID = aliasOf(NRIC);

--- a/js/src/nationalid/npl/national_id.js
+++ b/js/src/nationalid/npl/national_id.js
@@ -1,0 +1,25 @@
+import { validateRegexp } from '../util.js';
+
+const REGEXP = /^\d{11}$/;
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'NP',
+    min_length: 11,
+    max_length: 11,
+    parsable: false,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number', 'NIN'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#Nepal',
+      'https://nimc.gov.ng/about-nin/',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    return validateRegexp(idNumber, REGEXP);
+  }
+}

--- a/js/src/nationalid/tha/national_id.js
+++ b/js/src/nationalid/tha/national_id.js
@@ -1,0 +1,104 @@
+import { validateRegexp, weightedModulusDigit, modulusOverflowMod10 } from '../util.js';
+
+export const ThaiCitizenship = Object.freeze({
+  OTHER: 0,
+  CITIZEN_AFTER_1984: 1,
+  CITIZEN_AFTER_1984_LATE_REGISTERED: 2,
+  CITIZEN_BEFORE_1984: 3,
+  CITIZEN_BEFORE_1984_LATE_REGISTERED: 4,
+  CITIZEN_SPECIAL_CASE: 5,
+  FOREIGN_RESIDENT: 6,
+  FOREIGN_RESIDENT_CHILDREN: 7,
+  PERMANENT_RESIDENT: 8,
+});
+
+function normalize(idNumber) {
+  return idNumber.replace(/[ \-/]/g, '');
+}
+
+const REGEXP = /^(?<citizenship>[0-8])[ -]?(?<province>\d{2})(?<district>\d{2})[ -]?(?<sn>\d{5}[ -]?\d{2})[ -]?(?<checksum>\d)$/;
+const PROVINCE_LIST = ['10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','25','26','27','30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49','50','51','52','53','54','55','56','57','58','60','61','62','63','64','65','66','67','70','71','72','73','74','75','76','77','80','81','82','83','84','85','86','90','91','92','93','94','95','96'];
+const DISTRICT_MAX_VALUE = { '10':50,'11':6,'12':6,'13':7,'14':46,'15':7,'16':11,'17':9,'18':8,'19':12,'20':11,'21':8,'22':10,'23':7,'24':11,'25':9,'26':4,'27':9,'30':32,'31':23,'32':17,'33':22,'34':25,'35':9,'36':16,'37':6,'38':8,'39':6,'40':26,'41':25,'42':14,'43':9,'44':13,'45':20,'46':18,'47':18,'48':12,'49':7,'50':25,'51':8,'52':12,'53':9,'54':16,'55':15,'56':9,'57':18,'58':7,'60':15,'61':8,'62':11,'63':9,'64':9,'65':22,'66':13,'67':13,'70':10,'71':13,'72':10,'73':7,'74':3,'75':3,'76':7,'77':8,'80':23,'81':8,'82':8,'83':3,'84':19,'85':4,'86':8,'90':16,'91':7,'92':10,'93':11,'94':11,'95':8,'96':13};
+const DISTINCT_SPECIAL_CASE = { '44': [95] };
+const MAGIC_MULTIPLIER = [13,12,11,10,9,8,7,6,5,4,3,2];
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'TH',
+    min_length: 13,
+    max_length: 13,
+    parsable: true,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number','Population Identification Code','บัตรประชาชน','รหัสบัตรประชาชน'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#Thailand',
+      'https://learn.microsoft.com/en-us/microsoft-365/compliance/sit-defn-thai-population-identification-code?view=o365-worldwide'
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const citizenship = Number(match.groups.citizenship);
+    const province = match.groups.province;
+    const district = match.groups.district;
+    const sn = normalize(match.groups.sn);
+    if (!this.checkProvinceCode(province)) {
+      return null;
+    }
+    if (!this.checkDistrictCode(province, district)) {
+      return null;
+    }
+    if (!this.checksum(idNumber)) {
+      return null;
+    }
+    return {
+      citizenship,
+      province_code: province,
+      district_code: district,
+      sn,
+      checksum: Number(match.groups.checksum),
+    };
+  }
+
+  static checksum(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    const numbers = normalize(idNumber).split('').map((c) => Number(c));
+    const modulus = modulusOverflowMod10(
+      weightedModulusDigit(numbers.slice(0, -1), MAGIC_MULTIPLIER, 11)
+    );
+    return modulus === numbers[numbers.length - 1];
+  }
+
+  static checkProvinceCode(code) {
+    return PROVINCE_LIST.includes(code);
+  }
+
+  static checkDistrictCode(province, district) {
+    if (district === '99') {
+      return true;
+    }
+    const val = Number(district);
+    if (val <= DISTRICT_MAX_VALUE[province]) {
+      return true;
+    }
+    if (!(province in DISTINCT_SPECIAL_CASE)) {
+      return false;
+    }
+    return DISTINCT_SPECIAL_CASE[province].includes(val);
+  }
+}

--- a/js/src/nationalid/tur/national_id.js
+++ b/js/src/nationalid/tur/national_id.js
@@ -1,0 +1,37 @@
+import { validateRegexp, weightedModulusDigit } from '../util.js';
+
+const REGEXP = /^[1-9]\d{10}$/;
+const MULTIPLIERS = [7, -1, 7, -1, 7, -1, 7, -1, 7];
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'TR',
+    min_length: 11,
+    max_length: 11,
+    parsable: false,
+    checksum: true,
+    regexp: REGEXP,
+    alias_of: null,
+    names: [
+      'National ID Number',
+      'Türkiye Cumhuriyeti Kimlik Numarası',
+      'T.C. Kimlik No.',
+    ],
+    links: ['https://en.wikipedia.org/wiki/National_identification_number#Turkey'],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!validateRegexp(idNumber, REGEXP)) {
+      return false;
+    }
+    return this.checksum(idNumber) === idNumber.slice(-2);
+  }
+
+  static checksum(idNumber) {
+    const numbers = idNumber.split('').map((c) => Number(c));
+    const digitTen = weightedModulusDigit(numbers.slice(0, -2), MULTIPLIERS, 10, true);
+    const digitEleven = numbers.slice(0, -1).reduce((a, b) => a + b, 0) % 10;
+    return `${digitTen}${digitEleven}`;
+  }
+}

--- a/js/src/nationalid/usa/social_security.js
+++ b/js/src/nationalid/usa/social_security.js
@@ -1,0 +1,24 @@
+import { validateRegexp, aliasOf } from '../util.js';
+
+const REGEXP = /^(?!666|000|9\d{2})\d{3}-(?!00)\d{2}-(?!0{4})\d{4}$/;
+
+export class SocialSecurityNumber {
+  static METADATA = {
+    iso3166_alpha2: 'US',
+    min_length: 9,
+    max_length: 9,
+    parsable: false,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['Social Security number', 'SSN'],
+    links: ['https://en.wikipedia.org/wiki/National_identification_number#United_States'],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    return validateRegexp(idNumber, REGEXP);
+  }
+}
+
+export const NationalID = aliasOf(SocialSecurityNumber);

--- a/js/src/nationalid/vnm/national_id.js
+++ b/js/src/nationalid/vnm/national_id.js
@@ -1,0 +1,47 @@
+import { Gender } from '../constant.js';
+
+const REGEXP = /^(?<province_country_code>\d{3})(?<gender>\d)(?<yy>\d{2})(?<sn>\d{6})$/;
+
+export class NationalID {
+  static METADATA = {
+    iso3166_alpha2: 'VN',
+    min_length: 12,
+    max_length: 12,
+    parsable: true,
+    checksum: false,
+    regexp: REGEXP,
+    alias_of: null,
+    names: ['National ID Number', 'Thẻ căn cước công dân'],
+    links: [
+      'https://en.wikipedia.org/wiki/National_identification_number#Vietnam',
+      'https://vietnaminsider.vn/what-do-the-12-digits-on-the-citizen-id-card-with-chip-mean/',
+      'https://lawnet.vn/en/vb/Circular-07-2016-TT-BCA-detailing-Law-on-Citizen-Identification-137-2015-ND-CP-5CCC3.html',
+    ],
+    deprecated: false,
+  };
+
+  static validate(idNumber) {
+    if (!idNumber || typeof idNumber !== 'string') {
+      return false;
+    }
+    return this.parse(idNumber) !== null;
+  }
+
+  static parse(idNumber) {
+    const match = idNumber.match(REGEXP);
+    if (!match) {
+      return null;
+    }
+    const provinceCountryCode = match.groups.province_country_code;
+    const centuryGender = Number(match.groups.gender);
+    const yy = Number(match.groups.yy);
+    const sn = match.groups.sn;
+    const yyyy = 1900 + 100 * Math.floor(centuryGender / 2) + yy;
+    return {
+      province_country_code: provinceCountryCode,
+      yyyy,
+      sn,
+      gender: centuryGender % 2 === 0 ? Gender.MALE : Gender.FEMALE,
+    };
+  }
+}

--- a/js/test/chn.test.js
+++ b/js/test/chn.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { ResidentID, NationalID } from '../src/nationalid/chn/resident_id.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid ResidentID numbers', () => {
+  assert.strictEqual(ResidentID.validate('11010219840406970X'), true);
+  assert.strictEqual(ResidentID.validate('440524188001010014'), true);
+  assert.strictEqual(ResidentID.validate('11010519491231002X'), true);
+});
+
+test('invalid ResidentID numbers', () => {
+  assert.strictEqual(ResidentID.validate('11010219840506970X'), false);
+  assert.strictEqual(ResidentID.validate('440524189001010014'), false);
+  assert.strictEqual(ResidentID.validate('11020519491231002X'), false);
+});
+
+test('parse ResidentID', () => {
+  const result = ResidentID.parse('11010219840406970X');
+  assert.ok(result);
+  assert.strictEqual(result.address_code, '110102');
+  assert.strictEqual(result.yyyymmdd.getUTCFullYear(), 1984);
+  assert.strictEqual(result.yyyymmdd.getUTCMonth() + 1, 4);
+  assert.strictEqual(result.yyyymmdd.getUTCDate(), 6);
+  assert.strictEqual(result.sn, '970');
+  assert.strictEqual(result.gender, Gender.FEMALE);
+  assert.strictEqual(result.checksum, 'X');
+
+  const result2 = ResidentID.parse('440524188001010014');
+  assert.ok(result2);
+  assert.strictEqual(result2.address_code, '440524');
+  assert.strictEqual(result2.yyyymmdd.getUTCFullYear(), 1880);
+  assert.strictEqual(result2.yyyymmdd.getUTCMonth() + 1, 1);
+  assert.strictEqual(result2.yyyymmdd.getUTCDate(), 1);
+  assert.strictEqual(result2.sn, '001');
+  assert.strictEqual(result2.gender, Gender.MALE);
+  assert.strictEqual(result2.checksum, 4);
+});
+
+test('alias of', () => {
+  assert.strictEqual(ResidentID.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, ResidentID);
+});

--- a/js/test/deu.test.js
+++ b/js/test/deu.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { TaxID, NationalID, IdNr } from '../src/nationalid/deu/tax_id.js';
+
+test('valid Tax ID numbers', () => {
+  assert.strictEqual(TaxID.validate('65929970489'), true);
+  assert.strictEqual(TaxID.validate('26954371827'), true);
+  assert.strictEqual(TaxID.validate('86095742719'), true);
+});
+
+test('invalid Tax ID numbers', () => {
+  assert.strictEqual(TaxID.validate('65299970480'), false);
+  assert.strictEqual(TaxID.validate('26954371820'), false);
+});
+
+test('with regexp', () => {
+  assert.match('65929970489', TaxID.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(TaxID.METADATA);
+});
+
+test('alias of', () => {
+  assert.strictEqual(TaxID.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, TaxID);
+  assert.strictEqual(IdNr.METADATA.alias_of, TaxID);
+});

--- a/js/test/fra.test.js
+++ b/js/test/fra.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { INSEE, NationalID } from '../src/nationalid/fra/insee.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid INSEE numbers', () => {
+  assert.strictEqual(INSEE.validate('255081416802538'), true);
+  assert.strictEqual(INSEE.validate('283209921625930'), true);
+  assert.strictEqual(INSEE.validate('255082A16802597'), true);
+});
+
+test('invalid INSEE numbers', () => {
+  assert.strictEqual(INSEE.validate('180126955222381'), false);
+  assert.strictEqual(INSEE.validate('255082E16802597'), false);
+});
+
+test('parse INSEE', () => {
+  const result = INSEE.parse('255082A16802597');
+  assert.strictEqual(result.gender, Gender.FEMALE);
+  assert.strictEqual(result.yy, '55');
+  assert.strictEqual(result.mm, '08');
+  assert.strictEqual(result.checksum, '97');
+});
+
+test('with regexp', () => {
+  assert.match('255081416802538', INSEE.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(INSEE.METADATA);
+});
+
+test('alias of', () => {
+  assert.strictEqual(INSEE.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, INSEE);
+});

--- a/js/test/gbr.test.js
+++ b/js/test/gbr.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalInsuranceNumber, NationalID } from '../src/nationalid/gbr/national_insurance.js';
+
+test('valid NINO numbers', () => {
+  assert.strictEqual(NationalInsuranceNumber.validate('AB123456A'), true);
+  assert.strictEqual(NationalInsuranceNumber.validate('AA012344B'), true);
+});
+
+test('invalid NINO numbers', () => {
+  assert.strictEqual(NationalInsuranceNumber.validate('AD123456A'), false);
+  assert.strictEqual(NationalInsuranceNumber.validate('BO012344B'), false);
+  assert.strictEqual(NationalInsuranceNumber.validate('GB012344B'), false);
+  assert.strictEqual(NationalInsuranceNumber.validate('AB111111G'), false);
+});
+
+test('with regexp', () => {
+  assert.match('AB123456A', NationalInsuranceNumber.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NationalInsuranceNumber.METADATA);
+});
+
+test('alias of', () => {
+  assert.strictEqual(NationalInsuranceNumber.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, NationalInsuranceNumber);
+});

--- a/js/test/idn.test.js
+++ b/js/test/idn.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NIK, NationalID } from '../src/nationalid/idn/national_id.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid NIK numbers', () => {
+  assert.strictEqual(NIK.validate('7105100607610439'), true);
+  assert.strictEqual(NIK.validate('7105102902040439'), true);
+});
+
+test('invalid NIK numbers', () => {
+  assert.strictEqual(NIK.validate('7105102902020439'), false);
+  assert.strictEqual(NIK.validate('0950060607610439'), false);
+  assert.strictEqual(NIK.validate('7105101613610439'), false);
+  assert.strictEqual(NIK.validate('7105100607610000'), false);
+});
+
+test('parse NIK', () => {
+  const result = NIK.parse('7105100607610439');
+  assert.strictEqual(result.dd, '06');
+  assert.strictEqual(result.mm, '07');
+  assert.strictEqual(result.yy, '61');
+});
+
+test('with regexp', () => {
+  assert.match('7105100607610439', NIK.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NIK.METADATA);
+});
+
+test('alias of', () => {
+  assert.strictEqual(NIK.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, NIK);
+});

--- a/js/test/ita.test.js
+++ b/js/test/ita.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { FiscalCode, NationalID } from '../src/nationalid/ita/fiscal_code.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid Fiscal Code numbers', () => {
+  assert.strictEqual(FiscalCode.validate('MRTMTT91D08F205J'), true);
+  assert.strictEqual(FiscalCode.validate('MLLSNT82P65Z404U'), true);
+});
+
+test('invalid Fiscal Code numbers', () => {
+  assert.strictEqual(FiscalCode.validate('MRTMT91D08F205J'), false);
+  assert.strictEqual(FiscalCode.validate('MLLSNT82X65Z404U'), false);
+});
+
+test('parse Fiscal Code', () => {
+  let result = FiscalCode.parse('MLLSNT82P65Z404U');
+  assert.strictEqual(result.surname_consonants, 'MLL');
+  assert.strictEqual(result.firstname_consonants, 'SNT');
+  assert.strictEqual(result.yyyymmdd.getUTCFullYear(), 1982);
+  assert.strictEqual(result.yyyymmdd.getUTCMonth() + 1, 9);
+  assert.strictEqual(result.yyyymmdd.getUTCDate(), 25);
+  assert.strictEqual(result.area_code, 'Z404');
+  assert.strictEqual(result.checksum, 'U');
+  result = FiscalCode.parse('MRTMTT91D08F205J');
+  assert.strictEqual(result.surname_consonants, 'MRT');
+  assert.strictEqual(result.firstname_consonants, 'MTT');
+  assert.strictEqual(result.yyyymmdd.getUTCFullYear(), 1991);
+  assert.strictEqual(result.yyyymmdd.getUTCMonth() + 1, 4);
+  assert.strictEqual(result.yyyymmdd.getUTCDate(), 8);
+  assert.strictEqual(result.area_code, 'F205');
+  assert.strictEqual(result.checksum, 'J');
+});
+
+test('with regexp', () => {
+  assert.match('MRTMTT91D08F205J', FiscalCode.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(FiscalCode.METADATA);
+});
+
+test('alias of', () => {
+  assert.strictEqual(FiscalCode.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, FiscalCode);
+});

--- a/js/test/lka.test.js
+++ b/js/test/lka.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/nationalid/lka/national_id.js';
+import { OldNationalID } from '../src/nationalid/lka/old_national_id.js';
+import { Gender, Citizenship } from '../src/nationalid/constant.js';
+
+test('valid LKA numbers', () => {
+  assert.strictEqual(NationalID.validate('198713001450'), true);
+  assert.strictEqual(NationalID.validate('198571700717'), true);
+  assert.strictEqual(NationalID.validate('198732403040'), true);
+  assert.strictEqual(NationalID.validate('200159302029'), true);
+  assert.strictEqual(NationalID.validate('199612003996'), true);
+  assert.strictEqual(NationalID.validate('199234004783'), true);
+  assert.strictEqual(OldNationalID.validate('961203996V'), true);
+  assert.strictEqual(OldNationalID.validate('790930622V'), true);
+  assert.strictEqual(OldNationalID.validate('843020461V'), true);
+  assert.strictEqual(OldNationalID.validate('923404716V'), true);
+});
+
+test('invalid LKA numbers', () => {
+  assert.strictEqual(NationalID.validate('197419202757'), false);
+  assert.strictEqual(NationalID.validate('19741920275X'), false);
+  assert.strictEqual(OldNationalID.validate('790930622A'), false);
+});
+
+test('parse LKA numbers', () => {
+  const result = NationalID.parse('200159302029');
+  assert.strictEqual(result.yyyymmdd.getUTCFullYear(), 2001);
+  assert.strictEqual(result.yyyymmdd.getUTCMonth() + 1, 4);
+  assert.strictEqual(result.yyyymmdd.getUTCDate(), 3);
+  assert.strictEqual(result.gender, Gender.FEMALE);
+  assert.strictEqual(result.sn, '0202');
+  assert.strictEqual(result.checksum, 9);
+  const oldResult = OldNationalID.parse('923404716V');
+  assert.strictEqual(oldResult.yyyymmdd.getUTCFullYear(), 1992);
+  assert.strictEqual(oldResult.yyyymmdd.getUTCMonth() + 1, 12);
+  assert.strictEqual(oldResult.yyyymmdd.getUTCDate(), 5);
+  assert.strictEqual(oldResult.gender, Gender.MALE);
+  assert.strictEqual(oldResult.sn, '0471');
+  assert.strictEqual(oldResult.checksum, 6);
+  assert.strictEqual(oldResult.citizenship, Citizenship.CITIZEN);
+});
+
+test('convert old to new', () => {
+  assert.strictEqual(OldNationalID.toNew('961203996V'), '199612003996');
+});

--- a/js/test/mys.test.js
+++ b/js/test/mys.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NRIC, NationalID } from '../src/nationalid/mys/nric.js';
+import { Citizenship } from '../src/nationalid/constant.js';
+
+test('valid NRIC numbers', () => {
+  assert.strictEqual(NRIC.validate('691206-10-5330'), true);
+  assert.strictEqual(NRIC.validate('510317-13-5131'), true);
+  assert.strictEqual(NRIC.validate('690602-13-6118'), true);
+  assert.strictEqual(NRIC.validate('801101-06-6085'), true);
+});
+
+test('invalid NRIC numbers', () => {
+  assert.strictEqual(NRIC.validate('6912010533'), false);
+});
+
+test('parse NRIC', () => {
+  const result = NRIC.parse('690602-13-6118');
+  assert.strictEqual(result.yyyymmdd.getUTCFullYear(), 1969);
+  assert.strictEqual(result.yyyymmdd.getUTCMonth() + 1, 6);
+  assert.strictEqual(result.yyyymmdd.getUTCDate(), 2);
+  assert.strictEqual(result.location, '13');
+  assert.strictEqual(result.citizenship, Citizenship.CITIZEN);
+  assert.strictEqual(result.sn, '6118');
+});
+
+test('with regexp', () => {
+  assert.match('690602-13-6118', NRIC.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NRIC.METADATA);
+});
+
+test('alias of', () => {
+  assert.strictEqual(NRIC.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, NRIC);
+});

--- a/js/test/npl.test.js
+++ b/js/test/npl.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/nationalid/npl/national_id.js';
+
+test('valid NIN numbers', () => {
+  assert.strictEqual(NationalID.validate('12345678901'), true);
+});
+
+test('invalid NIN numbers', () => {
+  assert.strictEqual(NationalID.validate('1234567890'), false);
+});
+
+test('with regexp', () => {
+  assert.match('12345678901', NationalID.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NationalID.METADATA);
+});

--- a/js/test/tha.test.js
+++ b/js/test/tha.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID, ThaiCitizenship } from '../src/nationalid/tha/national_id.js';
+
+test('valid THA numbers', () => {
+  assert.strictEqual(NationalID.validate('3-8013-00141-07-4'), true);
+  assert.strictEqual(NationalID.validate('3 8013 00141 07 4'), true);
+  assert.strictEqual(NationalID.validate('3801300141074'), true);
+  assert.strictEqual(NationalID.validate('3 6701 01122 56 9'), true);
+  assert.strictEqual(NationalID.validate('3 4117 00830 33 4'), true);
+  assert.strictEqual(NationalID.validate('1 9099 00064 64 0'), true);
+  assert.strictEqual(NationalID.validate('5 9306 00015 56 7'), true);
+  assert.strictEqual(NationalID.validate('2 9014 01009 21 1'), true);
+});
+
+test('invalid THA numbers', () => {
+  assert.strictEqual(NationalID.validate('3-8013/00141-07-4'), false);
+  assert.strictEqual(NationalID.validate('3 8010141 07 4'), false);
+  assert.strictEqual(NationalID.validate('3801300141071'), false);
+});
+
+test('parse THA', () => {
+  const result = NationalID.parse('3 4117 00830 33 4');
+  assert.strictEqual(result.citizenship, ThaiCitizenship.CITIZEN_BEFORE_1984);
+  assert.strictEqual(result.province_code, '41');
+  assert.strictEqual(result.district_code, '17');
+  assert.strictEqual(result.sn, '0083033');
+  assert.strictEqual(result.checksum, 4);
+});
+
+test('with regexp', () => {
+  assert.match('3801300141074', NationalID.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NationalID.METADATA);
+});

--- a/js/test/tur.test.js
+++ b/js/test/tur.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/nationalid/tur/national_id.js';
+
+test('valid TUR numbers', () => {
+  assert.strictEqual(NationalID.validate('10000000146'), true);
+  assert.strictEqual(NationalID.validate('15973515680'), true);
+});
+
+test('invalid TUR numbers', () => {
+  assert.strictEqual(NationalID.validate('00000000178'), false);
+  assert.strictEqual(NationalID.validate('10000000145'), false);
+});
+
+test('with regexp', () => {
+  assert.match('10000000146', NationalID.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NationalID.METADATA);
+});

--- a/js/test/usa.test.js
+++ b/js/test/usa.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { SocialSecurityNumber, NationalID } from '../src/nationalid/usa/social_security.js';
+
+test('valid SSN numbers', () => {
+  assert.strictEqual(SocialSecurityNumber.validate('012-12-0928'), true);
+});
+
+test('invalid SSN numbers', () => {
+  assert.strictEqual(SocialSecurityNumber.validate('987-12-0928'), false);
+  assert.strictEqual(SocialSecurityNumber.validate('666-12-0000'), false);
+});
+
+test('with regexp', () => {
+  assert.match('012-12-0928', SocialSecurityNumber.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(SocialSecurityNumber.METADATA);
+});
+
+test('alias of', () => {
+  assert.strictEqual(SocialSecurityNumber.METADATA.alias_of, null);
+  assert.strictEqual(NationalID.METADATA.alias_of, SocialSecurityNumber);
+});

--- a/js/test/vnm.test.js
+++ b/js/test/vnm.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { NationalID } from '../src/nationalid/vnm/national_id.js';
+import { Gender } from '../src/nationalid/constant.js';
+
+test('valid VNM numbers', () => {
+  assert.strictEqual(NationalID.validate('020093001656'), true);
+});
+
+test('invalid VNM numbers', () => {
+  assert.strictEqual(NationalID.validate('0200930016561'), false);
+  assert.strictEqual(NationalID.validate('02009316561'), false);
+});
+
+test('parse VNM', () => {
+  const result = NationalID.parse('020093001656');
+  assert.strictEqual(result.province_country_code, '020');
+  assert.strictEqual(result.yyyy, 1993);
+  assert.strictEqual(result.gender, Gender.MALE);
+  assert.strictEqual(result.sn, '001656');
+});
+
+test('with regexp', () => {
+  assert.match('020093001656', NationalID.METADATA.regexp);
+});
+
+test('with metadata', () => {
+  assert.ok(NationalID.METADATA);
+});


### PR DESCRIPTION
## Summary
- port China Resident Identity Card logic from Python to JS
- validate and parse IDs with checksum and gender detection
- add unit tests for Chinese ResidentID
- add Nepal National ID validator and tests
- add UK National Insurance Number validator and tests
- add US Social Security Number validator and tests
- port additional national ID validators for France, Germany, Italy, Sri Lanka, Malaysia, Indonesia, Thailand, Vietnam and Turkey

## Testing
- `npm test --prefix js`
- `pytest tests/nationalid/test_FRA.py tests/nationalid/test_DEU.py tests/nationalid/test_ITA.py tests/nationalid/test_LKA.py tests/nationalid/test_MYS.py tests/nationalid/test_IDN.py tests/nationalid/test_THA.py tests/nationalid/test_VNM.py tests/nationalid/test_TUR.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4331db59c83328426d6498599c623